### PR TITLE
Rename app branding from Insight to Grow

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -239,7 +239,7 @@ export default function LoginScreen() {
               <Path d="M36.1367 7.8581C37.2413 7.8581 38.1367 8.75353 38.1367 9.8581C38.1367 10.9627 37.2413 11.8581 36.1367 11.8581C35.0321 11.8581 34.1367 10.9627 34.1367 9.8581C34.1367 8.75353 35.0321 7.8581 36.1367 7.8581Z" fill="#0F172A"/>
             </Svg>
           </View>
-          <Text style={{ fontFamily: 'GeistMono_600SemiBold' }} className="text-slate-800 text-2xl">Insight</Text>
+          <Text style={{ fontFamily: 'GeistMono_600SemiBold' }} className="text-slate-800 text-2xl">Grow</Text>
         </View>
       </View>
 

--- a/components/ProfileHeader.tsx
+++ b/components/ProfileHeader.tsx
@@ -35,7 +35,7 @@ export const ProfileHeader: React.FC<ProfileHeaderProps> = ({ onProfilePress }) 
           <Path d="M36.1367 7.8581C37.2413 7.8581 38.1367 8.75353 38.1367 9.8581C38.1367 10.9627 37.2413 11.8581 36.1367 11.8581C35.0321 11.8581 34.1367 10.9627 34.1367 9.8581C34.1367 8.75353 35.0321 7.8581 36.1367 7.8581Z" fill="#0F172A"/>
         </Svg>
         <Text style={{ fontFamily: 'GeistMono_600SemiBold' }} className="text-black text-2xl">
-          Insight
+          Grow
         </Text>
       </View>
       

--- a/config/auth.ts
+++ b/config/auth.ts
@@ -12,7 +12,7 @@ export const GOOGLE_OAUTH_CONFIG = {
   CLIENT_ID: Constants.expoConfig?.extra?.googleClientId || '',
   CLIENT_SECRET: Constants.expoConfig?.extra?.googleClientSecret || '',
   REDIRECT_URI: NODE_ENV === 'production' 
-    ? 'https://insight.string.sg/' // Your production domain
+    ? 'https://grow.string.sg/' // Your production domain
     : 'http://localhost:8081/',
 };
 


### PR DESCRIPTION
Updated visible app name in login and profile header from 'Insight' to 'Grow'. Also changed the Google OAuth production redirect URI to use the new 'grow.string.sg' domain.